### PR TITLE
Support circular requires as per Node.js

### DIFF
--- a/src/main/java/com/coveo/nashorn_modules/Require.java
+++ b/src/main/java/com/coveo/nashorn_modules/Require.java
@@ -1,10 +1,10 @@
 package com.coveo.nashorn_modules;
 
+import jdk.nashorn.api.scripting.NashornScriptEngine;
+
 import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
-
-import jdk.nashorn.api.scripting.NashornScriptEngine;
 
 public class Require {
   public static Module enable(NashornScriptEngine engine, Folder folder) throws ScriptException {

--- a/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
+++ b/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
@@ -1,25 +1,20 @@
 package com.coveo.nashorn_modules;
 
+import jdk.nashorn.api.scripting.NashornException;
+import jdk.nashorn.api.scripting.NashornScriptEngine;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import javax.script.Bindings;
+import javax.script.ScriptEngineManager;
 import java.io.File;
 import java.util.ArrayList;
 
-import javax.script.Bindings;
-import javax.script.ScriptEngineManager;
-
-import jdk.nashorn.api.scripting.NashornException;
-import jdk.nashorn.api.scripting.NashornScriptEngine;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -482,5 +477,13 @@ public class ModuleTest {
     FilesystemFolder root = FilesystemFolder.create(file, "UTF-8");
     require = Require.enable(engine, root);
     engine.eval("require('fbjs/lib/invariant')");
+  }
+
+  @Test
+  public void itCanShortCircuitCircularRequireReferences() throws Throwable {
+    File file = new File("src/test/resources/com/coveo/nashorn_modules/test4/cycles");
+    FilesystemFolder root = FilesystemFolder.create(file, "UTF-8");
+    require = Require.enable(engine, root);
+    engine.eval("require('./main.js')");
   }
 }

--- a/src/test/resources/com/coveo/nashorn_modules/test4/cycles/a.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test4/cycles/a.js
@@ -1,0 +1,1 @@
+var b = require('./b.js');

--- a/src/test/resources/com/coveo/nashorn_modules/test4/cycles/b.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test4/cycles/b.js
@@ -1,0 +1,1 @@
+var a = require('./a.js');

--- a/src/test/resources/com/coveo/nashorn_modules/test4/cycles/main.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test4/cycles/main.js
@@ -1,0 +1,2 @@
+var a = require('./a.js');
+var b = require('./b.js');


### PR DESCRIPTION
Many node modules out there contain circular require references (I know, right?), so I feel that this CommonJS loader could benefit from support for successfully resolving them like Node does.

* Added a test which previously caused a stackoverflowerror
* Added refCache to Module that contains temporary bindings during resolution

As per: https://nodejs.org/api/modules.html#modules_cycles

Just noticed that my editor has been messing with imports. I'm happy to revert if you like.