### PR TITLE
Allow properties to be set on exports object

### DIFF
--- a/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
+++ b/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
@@ -13,6 +13,7 @@ import javax.script.Bindings;
 import javax.script.ScriptEngineManager;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -279,7 +280,7 @@ public class ModuleTest {
     Bindings exports = (Bindings) engine.eval("require('./file1')._exports");
     Bindings main = (Bindings) engine.eval("require('./file1')._main");
 
-    assertEquals(exports, module.get("exports"));
+    assertEquals(exports.entrySet(), ((Map) module.get("exports")).entrySet());
     assertEquals(new ArrayList(), module.get("children"));
     assertEquals("/file1.js", module.get("filename"));
     assertEquals("/file1.js", module.get("id"));
@@ -303,7 +304,7 @@ public class ModuleTest {
     Bindings exports = (Bindings) engine.eval("require('./sub1/sub1file1')._exports");
     Bindings main = (Bindings) engine.eval("require('./sub1/sub1file1')._main");
 
-    assertEquals(exports, module.get("exports"));
+    assertEquals(exports.entrySet(), ((Map) module.get("exports")).entrySet());
     assertEquals(new ArrayList(), module.get("children"));
     assertEquals("/sub1/sub1file1.js", module.get("filename"));
     assertEquals("/sub1/sub1file1.js", module.get("id"));
@@ -327,7 +328,7 @@ public class ModuleTest {
     Bindings exports = (Bindings) engine.eval("require('./sub1/sub1/sub1sub1file1')._exports");
     Bindings main = (Bindings) engine.eval("require('./sub1/sub1/sub1sub1file1')._main");
 
-    assertEquals(exports, module.get("exports"));
+    assertEquals(exports.entrySet(), ((Map) module.get("exports")).entrySet());
     assertEquals(new ArrayList(), module.get("children"));
     assertEquals("/sub1/sub1/sub1sub1file1.js", module.get("filename"));
     assertEquals("/sub1/sub1/sub1sub1file1.js", module.get("id"));
@@ -485,5 +486,13 @@ public class ModuleTest {
     FilesystemFolder root = FilesystemFolder.create(file, "UTF-8");
     require = Require.enable(engine, root);
     engine.eval("require('./main.js')");
+  }
+
+  @Test
+  public void itCanDefinePropertiesOnExportsObject() throws Throwable {
+    File file = new File("src/test/resources/com/coveo/nashorn_modules/test5");
+    FilesystemFolder root = FilesystemFolder.create(file, "UTF-8");
+    require = Require.enable(engine, root);
+    engine.eval("require('./exports.js')");
   }
 }

--- a/src/test/resources/com/coveo/nashorn_modules/test5/exports.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test5/exports.js
@@ -1,0 +1,1 @@
+Object.defineProperty(exports, "__esModule", { value: true });


### PR DESCRIPTION
The following code:

```js
Object.defineProperty(exports, "__esModule", { value: true });
```

does not work in Nashorn, leading to an Exception:

```
Caused by: .atomist/editors/SimpleEditor.js:10 TypeError: [object global] is not an Object
	at jdk.nashorn.internal.runtime.ECMAErrors.error(ECMAErrors.java:57)
	at jdk.nashorn.internal.runtime.ECMAErrors.typeError(ECMAErrors.java:213)
	at jdk.nashorn.internal.runtime.ECMAErrors.typeError(ECMAErrors.java:185)
	at jdk.nashorn.internal.runtime.ECMAErrors.typeError(ECMAErrors.java:172)
	at jdk.nashorn.internal.objects.Global.checkObject(Global.java:2061)
	at jdk.nashorn.internal.objects.NativeObject.defineProperty(NativeObject.java:286)
	at jdk.nashorn.internal.scripts.Script$Recompilation$9$60AAAAA$SimpleEditor.L:1(.atomist/editors/SimpleEditor.js:10)
	at jdk.nashorn.internal.runtime.ScriptFunctionData.invoke(ScriptFunctionData.java:647)
	at jdk.nashorn.internal.runtime.ScriptFunction.invoke(ScriptFunction.java:494)
	at jdk.nashorn.internal.runtime.ScriptRuntime.apply(ScriptRuntime.java:393)
	at jdk.nashorn.api.scripting.ScriptObjectMirror.call(ScriptObjectMirror.java:117)
	at com.coveo.nashorn_modules.Module.compileJavaScriptModule(Module.java:298)
	at com.coveo.nashorn_modules.Module.compileModuleAndPutInCache(Module.java:259)
	at com.coveo.nashorn_modules.Module.loadModuleAsFile(Module.java:182)
	at com.coveo.nashorn_modules.Module.attemptToLoadFromThisFolder(Module.java:157)
	at com.coveo.nashorn_modules.Module.require(Module.java:98)
```
This is because our `exports` object is a Nashorn Bindings object, and Nashorn only supports defining properties on pure JS objects (those that extend ScriptObject - an internal Nashorn class).

We are experiencing this issue due to a change in the TypeScript compiler:

https://github.com/Microsoft/TypeScript/issues/14351

but it's not uncommon for other JS processing tools to do the same:

https://duckduckgo.com/?q=Object.defineProperty(exports%2C+%22__esModule%22%2C+%7B+value%3A+true+%7D)%3B&atb=v51-6_c&ia=web

and of course, it's totally valid JavaScript

Ultimately, we may want to consider doing this for all global vars, but this seemed like a _much_ more invasive change to the design.