### PR TITLE
Use real JS object whenever we need an instance of Bindings

### DIFF
--- a/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
+++ b/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
@@ -1,20 +1,25 @@
 package com.coveo.nashorn_modules;
 
-import jdk.nashorn.api.scripting.NashornException;
-import jdk.nashorn.api.scripting.NashornScriptEngine;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import javax.script.Bindings;
-import javax.script.ScriptEngineManager;
 import java.io.File;
 import java.util.ArrayList;
 
-import static org.junit.Assert.*;
+import javax.script.Bindings;
+import javax.script.ScriptEngineManager;
+
+import jdk.nashorn.api.scripting.NashornException;
+import jdk.nashorn.api.scripting.NashornScriptEngine;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -479,11 +484,21 @@ public class ModuleTest {
     engine.eval("require('fbjs/lib/invariant')");
   }
 
+  // Checks for https://github.com/coveo/nashorn-commonjs-modules/pull/14
+
   @Test
   public void itCanShortCircuitCircularRequireReferences() throws Throwable {
     File file = new File("src/test/resources/com/coveo/nashorn_modules/test4/cycles");
     FilesystemFolder root = FilesystemFolder.create(file, "UTF-8");
     require = Require.enable(engine, root);
     engine.eval("require('./main.js')");
+  }
+
+  // Checks for https://github.com/coveo/nashorn-commonjs-modules/issues/15
+
+  @Test
+  public void itCanDefinePropertiesOnExportsObject() throws Throwable {
+    when(root.getFile("file1.js")).thenReturn("Object.defineProperty(exports, '__esModule', { value: true });");
+    engine.eval("require('./file1.js')");
   }
 }


### PR DESCRIPTION
As pointed out by @kipz in [this PR](https://github.com/coveo/nashorn-commonjs-modules/pull/16/files) Nashorn doesn't support defining properties on instances of `SimpleBindings`. I took the liberty to extend his proposed fix in order to use JS objects pretty much everywhere those were used. This should address issue #15.