### PR TITLE
Allow registering the `require` function in a specific binding, to allow re-using a ScriptEngine across multiple threads.

### DIFF
--- a/src/main/java/com/coveo/nashorn_modules/Require.java
+++ b/src/main/java/com/coveo/nashorn_modules/Require.java
@@ -1,23 +1,33 @@
 package com.coveo.nashorn_modules;
 
-import jdk.nashorn.api.scripting.NashornScriptEngine;
-
 import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
 
+import jdk.nashorn.api.scripting.NashornScriptEngine;
+
 public class Require {
+  // This overload registers the require function globally in the engine scope
   public static Module enable(NashornScriptEngine engine, Folder folder) throws ScriptException {
+    Bindings global = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+    return enable(engine, folder, global);
+  }
+
+  // This overload registers the require function in a specific Binding. It is useful when re-using the
+  // same script engine across multiple threads (each thread should have his own global scope defined
+  // through the binding that is passed as an argument).
+  public static Module enable(NashornScriptEngine engine, Folder folder, Bindings bindings)
+      throws ScriptException {
     Bindings module = engine.createBindings();
     Bindings exports = engine.createBindings();
+
     Module created =
         new Module(engine, folder, new ModuleCache(), "<main>", module, exports, null, null);
     created.setLoaded();
 
-    Bindings global = engine.getBindings(ScriptContext.ENGINE_SCOPE);
-    global.put("require", created);
-    global.put("module", module);
-    global.put("exports", exports);
+    bindings.put("require", created);
+    bindings.put("module", module);
+    bindings.put("exports", exports);
 
     return created;
   }

--- a/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
+++ b/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
@@ -10,7 +10,10 @@ import java.io.File;
 import java.util.ArrayList;
 
 import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
 
 import jdk.nashorn.api.scripting.NashornException;
 import jdk.nashorn.api.scripting.NashornScriptEngine;
@@ -19,7 +22,9 @@ import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +73,32 @@ public class ModuleTest {
   @Test
   public void itCanLoadSimpleModules() throws Throwable {
     assertEquals("file1", ((Bindings) require.require("./file1.js")).get("file1"));
+  }
+
+  @Test
+  public void itCanEnableRequireInDifferentBindingsOnTheSameEngine() throws Throwable {
+    NashornScriptEngine engine =
+        (NashornScriptEngine) new ScriptEngineManager().getEngineByName("nashorn");
+    Bindings bindings1 = new SimpleBindings();
+    Bindings bindings2 = new SimpleBindings();
+
+    Require.enable(engine, root, bindings1);
+
+    assertNull(engine.getBindings(ScriptContext.ENGINE_SCOPE).get("require"));
+    assertNotNull(bindings1.get("require"));
+    assertNull(bindings2.get("require"));
+    assertEquals("file1", ((Bindings) engine.eval("require('./file1')", bindings1)).get("file1"));
+
+    try {
+      engine.eval("require('./file1')", bindings2);
+      fail();
+    } catch (ScriptException ignored) {
+    }
+
+    Require.enable(engine, root, bindings2);
+    assertNull(engine.getBindings(ScriptContext.ENGINE_SCOPE).get("require"));
+    assertNotNull(bindings2.get("require"));
+    assertEquals("file1", ((Bindings) engine.eval("require('./file1')", bindings2)).get("file1"));
   }
 
   @Test


### PR DESCRIPTION
As explained in #12, it's sometimes desirable to re-use the same Script Engine in multiple threads, with each thread having it's own `Bindings` defining the global scope. I added an overload to `Require` that does just this. The `Module` still gets passed the `NashornScriptEngine` reference, but I think that's OK since it only uses it to access engine scope and create a few standard JS objects.