### PR TITLE
Only clear ref-cache for current module being resolved

### DIFF
--- a/src/main/java/com/coveo/nashorn_modules/Module.java
+++ b/src/main/java/com/coveo/nashorn_modules/Module.java
@@ -97,8 +97,9 @@ public class Module extends SimpleBindings implements RequireFunction {
       refCache.set(new HashMap<>());
     }
 
+    String requestedFullPath = null;
     if (resolvedFolder != null) {
-      String requestedFullPath = resolvedFolder.getPath() + filename;
+      requestedFullPath = resolvedFolder.getPath() + filename;
       Bindings cachedExports = refCache.get().get(requestedFullPath);
       if (cachedExports != null) {
         return cachedExports;
@@ -130,8 +131,10 @@ public class Module extends SimpleBindings implements RequireFunction {
       return found.exports;
 
     } finally {
-      // Finally, remove successful resolves from the refCache
-      refCache.remove();
+      // Finally, we remove the successful resolved module from the refCache
+      if(requestedFullPath != null){
+        refCache.get().remove(requestedFullPath);
+      }
     }
   }
 

--- a/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
+++ b/src/test/java/com/coveo/nashorn_modules/ModuleTest.java
@@ -494,6 +494,14 @@ public class ModuleTest {
     engine.eval("require('./main.js')");
   }
 
+  @Test
+  public void itCanShortCircuitDeepCircularRequireReferences() throws Throwable {
+    File file = new File("src/test/resources/com/coveo/nashorn_modules/test4/deep");
+    FilesystemFolder root = FilesystemFolder.create(file, "UTF-8");
+    require = Require.enable(engine, root);
+    engine.eval("require('./main.js')");
+  }
+
   // Checks for https://github.com/coveo/nashorn-commonjs-modules/issues/15
 
   @Test

--- a/src/test/resources/com/coveo/nashorn_modules/test4/deep/a.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test4/deep/a.js
@@ -1,0 +1,2 @@
+var c = require('./c.js');
+var b = require('./b.js');

--- a/src/test/resources/com/coveo/nashorn_modules/test4/deep/b.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test4/deep/b.js
@@ -1,0 +1,2 @@
+var c = require('./c.js');
+var a = require('./a.js');

--- a/src/test/resources/com/coveo/nashorn_modules/test4/deep/c.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test4/deep/c.js
@@ -1,0 +1,1 @@
+var woot = "woot"

--- a/src/test/resources/com/coveo/nashorn_modules/test4/deep/main.js
+++ b/src/test/resources/com/coveo/nashorn_modules/test4/deep/main.js
@@ -1,0 +1,2 @@
+var a = require('./a.js');
+var b = require('./b.js');


### PR DESCRIPTION
With out this, the new test case `itCanShortCircuitDeepCircularRequireReferences` causes a StackOverflowError because we cleared the _whole_ ref-cache when we unwind the stack, rather than just removing the resolved module from it.