### PR TITLE
Create path using File.separator instead of "/"

### DIFF
--- a/src/main/java/com/coveo/nashorn_modules/FilesystemFolder.java
+++ b/src/main/java/com/coveo/nashorn_modules/FilesystemFolder.java
@@ -39,11 +39,11 @@ public class FilesystemFolder extends AbstractFolder {
       return null;
     }
 
-    return new FilesystemFolder(folder, this, getPath() + name + "/", encoding);
+    return new FilesystemFolder(folder, this, getPath() + name + File.separator, encoding);
   }
 
   public static FilesystemFolder create(File root, String encoding) {
     File absolute = root.getAbsoluteFile();
-    return new FilesystemFolder(absolute, null, absolute.getPath() + "/", encoding);
+    return new FilesystemFolder(absolute, null, absolute.getPath() + File.separator, encoding);
   }
 }

--- a/src/test/java/com/coveo/nashorn_modules/FilesystemFolderTest.java
+++ b/src/test/java/com/coveo/nashorn_modules/FilesystemFolderTest.java
@@ -17,10 +17,15 @@ public class FilesystemFolderTest {
   private File file = new File("src/test/resources/com/coveo/nashorn_modules/test1");
   private FilesystemFolder root = FilesystemFolder.create(file, "UTF-8");
 
+  private File subfile = new File(file, "subdir");
+  private File subsubfile = new File(subfile, "subsubdir");
+
+  private String rootPath = file.getAbsolutePath().substring(0, file.getAbsolutePath().indexOf(File.separator));
+
   @Test
   public void rootFolderHasTheExpectedProperties() {
-    assertTrue(root.getPath().startsWith("/"));
-    assertTrue(root.getPath().endsWith("/src/test/resources/com/coveo/nashorn_modules/test1/"));
+    assertTrue(root.getPath().startsWith(rootPath));
+    assertTrue(root.getPath().endsWith(file.getPath() + File.separator));
     assertNull(root.getParent());
   }
 
@@ -37,16 +42,12 @@ public class FilesystemFolderTest {
   @Test
   public void getFolderReturnsAnObjectWithTheExpectedProperties() {
     Folder sub = root.getFolder("subdir");
-    assertTrue(sub.getPath().startsWith("/"));
-    assertTrue(
-        sub.getPath().endsWith("/src/test/resources/com/coveo/nashorn_modules/test1/subdir/"));
+    assertTrue(sub.getPath().startsWith(rootPath));
+    assertTrue(sub.getPath().endsWith(subfile.getPath() + File.separator));
     assertSame(root, sub.getParent());
     Folder subsub = sub.getFolder("subsubdir");
-    assertTrue(subsub.getPath().startsWith("/"));
-    assertTrue(
-        subsub
-            .getPath()
-            .endsWith("/src/test/resources/com/coveo/nashorn_modules/test1/subdir/subsubdir/"));
+    assertTrue(subsub.getPath().startsWith(rootPath));
+    assertTrue(subsub.getPath().endsWith(subsubfile.getPath() + File.separator));
     assertSame(sub, subsub.getParent());
   }
 


### PR DESCRIPTION
In order to fix [#28](https://github.com/coveo/nashorn-commonjs-modules/issues/28) I propose:
- in `FilesystemFolder `use `File.separator` instead of "/"
- in `FilesystemFolderTest `remove all assert based on string constants and instead create `File `object for the test folders and use `File.getPath` and `File.separator` to create the root path to use when assert `Folder.getPath.startsWith` and instead use `File.separator` to assert `Folder.getPath.endsWith`
